### PR TITLE
Fix PyPI upload authentication

### DIFF
--- a/.github/workflows/microarch.yml
+++ b/.github/workflows/microarch.yml
@@ -45,6 +45,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 


### PR DESCRIPTION
## Problem
PyPI upload was failing with:
```
Error: Trusted publishing exchange failure: 
OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions
```

The action was attempting to use Trusted Publishing (OIDC) by default, but the workflow doesn't have the required `id-token: write` permissions.

## Solution
Add `user: __token__` to explicitly use API token authentication instead of OIDC.

## Changes
- ✅ Add `user: __token__` to PyPI upload step
- ✅ Forces use of existing `PYPI_API_TOKEN` secret
- ✅ Avoids need for OIDC/Trusted Publishing configuration

## Alternative
We could instead add OIDC permissions:
```yaml
permissions:
  id-token: write
```

But using the API token is simpler since it's already configured.

## Testing
After merging, the next push to master will successfully upload to PyPI using the token method.