### PR TITLE
Enable PyPI upload for testing secret configuration

### DIFF
--- a/.github/workflows/microarch.yml
+++ b/.github/workflows/microarch.yml
@@ -42,10 +42,9 @@ jobs:
           python setup.py sdist
 
       - name: Upload to PyPI
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'  # Temporarily disabled for testing
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 


### PR DESCRIPTION
## Purpose
Temporarily enable PyPI upload on all branches to test if the `PYPI_API_TOKEN` secret is properly configured in the k-nuth organization.

## Changes
- ✅ Commented out `if: github.ref == 'refs/heads/master'` restriction
- ✅ Removed `user: __token__` (works without it in fpelliccioni repos)
- ✅ Kept `skip-existing: true` to avoid errors on duplicate uploads

## Why
The PyPI upload was failing with OIDC errors, but this same configuration works in:
- fpelliccioni/cpuid-py-native
- fpelliccioni/cpuid-py

The difference is this repo is under the **k-nuth** organization, so the `PYPI_API_TOKEN` secret needs to be configured at the organization or repository level.

## Next Steps
1. Configure `PYPI_API_TOKEN` secret in k-nuth/march repository settings
2. Test upload by pushing to this PR branch
3. Once working, restore master-only restriction:
   ```yaml
   if: github.ref == 'refs/heads/master'
   ```

## Secret Configuration
Go to: https://github.com/k-nuth/march/settings/secrets/actions

Add secret:
- **Name**: `PYPI_API_TOKEN`
- **Value**: Your PyPI API token